### PR TITLE
fix(st7789): improve PWM backlight dimming color accuracy

### DIFF
--- a/hw/display/st7789v.c
+++ b/hw/display/st7789v.c
@@ -334,13 +334,15 @@ static void st7789_update_display(void *opaque) {
         for(int x=0;x<c->width;x++) {
             uint16_t rgb565=c->fb_data[(y+c->y_offset)*320+x+c->x_offset];
             if(c->backlight<255) {
-                uint32_t r=(rgb565>>8) & 0xf8;
-                uint32_t g=(rgb565>>3) & 0xfc;
-                uint32_t b=(rgb565<<2) & 0xf8;
-                r=(r*c->backlight)/256;
-                g=(g*c->backlight)/256;
-                b=(b*c->backlight)/256;
-                rgb565=(uint16_t)(((r >> 3) << 11) | ((g >> 2) << 5)  | ( b >> 3));
+                // Extract native-bit counts
+                uint32_t r = (rgb565 >> 11) & 0x1F;
+                uint32_t g = (rgb565 >> 5) & 0x3F;
+                uint32_t b = rgb565 & 0x1F;
+                // Scale with rounding-to-nearest (add half LSB before shift)
+                r = (r * c->backlight + 127) >> 8;
+                g = (g * c->backlight + 127) >> 8;
+                b = (b * c->backlight + 127) >> 8;
+                rgb565=(uint16_t)((r << 11) | (g << 5) | b);
             }
             uint32_t index=(y+c->skin_y_offset)*c->skin_width+x+c->skin_x_offset;
             if(index<320*320)


### PR DESCRIPTION
Original code expanded RGB565 to 8-bit channels, multiplied with truncating division (/256), then shifted back, causing consistent darkening and minor hue errors, especially noticeable at 40–80% brightness.

Improved version:
- Extracts components in native precision: 5-bit red/blue, 6-bit green
- Scales with proper rounding: (val * backlight + 127) >> 8
- Packs directly back to RGB565 format

Improves visual quality dramatically:
- Grays/whites stay neutral instead of going too dark or greenish
- Better preservation of shadow detail
- More natural fade-to-black behavior overall

Before: 

<img width="496" height="208" alt="90p_brightness_default_scroll" src="https://github.com/user-attachments/assets/b41cd712-a0c4-429d-b5dc-16860e45f205" />

_at 90% brightness, the gray and blue turned greenish_

After:
<img width="496" height="208" alt="90p_brightness_fixed_scroll" src="https://github.com/user-attachments/assets/63a166f5-5081-49d3-864d-3ac8beea8412" />

_at 90% brightness, all the colors look as they should_