### PR TITLE
esp32s3 t-display-s3: emulate external pullups

### DIFF
--- a/hw/gpio/esp32s3_gpio.c
+++ b/hw/gpio/esp32s3_gpio.c
@@ -953,6 +953,8 @@ static void ESP32S3_GPIO_reset(Object *dev, ResetType type) {
         if(reset_type==4) {
             if(i<32) s->gpio_enable=1<<i; else s->gpio_enable1=1<<(i-32);
         }
+        // Emulate the external pullup resistors on the GPIO0/GPIO14 buttons of the T-Display-S3
+        if (i == 0 || i == 14) v = FIELD_DP32(v, IO_MUX, FUN_WPU, 1);
         s->iomux_regs[i+1]=v;
     }
 }


### PR DESCRIPTION
Emulate the external pullup resistors on
the GPIO0/GPIO14 buttons of the T-Display-S3.

On the physical t-display-s3, this works:

```
pin0 = Pin(0, Pin.IN)
pin0.value() # returns 1 (as it should because it's pulled high by an external resistor)
```

But on the emulator, the same code behaves differently:

```
pin0 = Pin(0, Pin.IN)
pin0.value() # returns 0 because external pullups weren't emulated
```

This commit makes the emulator implement the hardware pullups so it better mimics the real hardware.

BTW, internal pullups have been implemented already in commit cbb15d7ff066 at https://github.com/a159x36/qemu/pull/2/changes so this workaround would also work:

```
pin0 = Pin(0, Pin.IN, Pin.PULL_UP)
pin0.value() # returns 1 when internal pullups are supported
```
